### PR TITLE
Add Openwith -> itk-vtk viewer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,10 @@ Configuration
 
     $ omero config append omero.web.open_with '["web_zarr_validator", "omero_web_zarr_index", {"supported_objects":["image"], "label": "NGFF validator", "script_url": "omero_web_zarr/openwith_validator.js"}]'
 
+    # Open with vtk-itk viewer
+
+    $ omero config append omero.web.open_with '["web_zarr_itkvtk", "omero_web_zarr_index", {"supported_objects":["image"], "label": "itk-vtk viewer", "script_url": "omero_web_zarr/openwith_itkvtk.js"}]'
+
 
 Then you will be able to access OMERO Images in OME-NGFF format v0.3 or v0.4 with a URLs like::
 

--- a/omero_web_zarr/static/omero_web_zarr/openwith_itkvtk.js
+++ b/omero_web_zarr/static/omero_web_zarr/openwith_itkvtk.js
@@ -1,0 +1,5 @@
+// Here we configure a url provider. This function will be passed the selected
+// objects and the base url that was specified in the 'Open with' configuration above.
+OME.setOpenWithUrlProvider("web_zarr_itkvtk", function (selected, url) {
+    return `${url}itkvtk/?fileToLoad=${url}v0.4/image/${selected[0].id}.zarr&rotate=false`
+});

--- a/omero_web_zarr/urls.py
+++ b/omero_web_zarr/urls.py
@@ -37,6 +37,6 @@ urlpatterns = [
         views.image_chunk, name='zarr_image_chunk'),
 
     # Delegate all /vizarr/ or /validator/ urls to statically-hosted files
-    url(r'^(?P<app>vizarr|validator)/(?P<url>.*)$', views.apps, name='zarr_app'),  # noqa
+    url(r'^(?P<app>vizarr|validator|itkvtk)/(?P<url>.*)$', views.apps, name='zarr_app'),  # noqa
 
 ]

--- a/omero_web_zarr/views.py
+++ b/omero_web_zarr/views.py
@@ -285,18 +285,30 @@ def apps(request, app, url):
     """
 
     # Both vizarr and validator use 'source'
+
+    source_keys = {
+        "vizarr": "source",
+        "validator": "source",
+        "itkvtk": "fileToLoad"
+    }
+
     # Openwith initially uses a 'source' that is not a valid URL e.g.
     # http://omero-server.org/zarr/vizarr/?source=/zarr/image/3978085.zarr
     # If so, make the 'source' absolute and redirect...
-    source = request.GET.get("source")
+    source_key = source_keys[app]
+    source = request.GET.get(source_key)
     if source is not None and not source.startswith("http"):
         source = request.build_absolute_uri(source)
         new_url = reverse("zarr_app", kwargs={"url": "", "app": app})
-        return redirect(new_url + "?source=" + source)
+        query_dict = request.GET.copy()
+        query_dict[source_key] = source
+        return redirect(new_url + "?" + query_dict.urlencode())
 
+    # load static content from these URLs
     base_urls = {
         "vizarr": "https://hms-dbmi.github.io/vizarr/",
         "validator": "https://ome.github.io/ome-ngff-validator/",
+        "itkvtk": "https://kitware.github.io/itk-vtk-viewer/app/"
     }
     if app not in base_urls:
         raise Http404("App: %s not found" % app)


### PR DESCRIPTION
This adds itk-vtk viewer to the Open-with options when `omero-web-zarr` is installed.
It can take a while to load (screenshots are loading an image from nightshade, using local omero-web) but gives a different 3D viewer as an alternative to FPBioImage:

See README for config.

![Screenshot 2023-05-11 at 15 22 58](https://github.com/ome/omero-web-zarr/assets/900055/b851cca8-22b2-4e4a-b650-043915a46456)

![Screenshot 2023-05-11 at 15 17 17](https://github.com/ome/omero-web-zarr/assets/900055/e83881b3-3091-455a-8f15-46afd07bfbc3)

cc @pwalczysko 