### PR TITLE
Viewing s3 data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Install with::
     $ pip install -e .
 
 Configuration
+-------------
 
 ::
 
@@ -66,6 +67,28 @@ This omero-web app self-hosts Vizarr to avoid CORS issues (delegating to https:/
 In the webclient UI you can use the context menu to `Open With > Vizarr`, or use your Image ID and go directly to::
 
     [omero-server]/zarr/vizarr/?source=[omero-server]/zarr/v0.4/image/[ID].zarr
+
+Viewing s3 data
+---------------
+
+If you have imported OME-Zarr images into OMERO and the data is publicly accessible, e.g. hosted
+on s3, then you can use this app to view that s3 data directly (instead of using the OMERO server).
+This relies on the public data source being set as the `clientPath` location (shown in the webclient
+as "Imported From"). At least 1 `clientPath` for an Image or Plate should be in the form:
+`http....zarr/.zattrs`.
+For data that matches this criteria, we can replace the image-viewer with `vizarr`` (images that do not
+have such a clientPath will default to using iviewer):
+
+::
+
+    $ omero config set omero.web.viewer.view omero_web_zarr.views.vizarr_or_iviewer
+
+We can also enable a right-panel plugin tab that will show `vizarr`` in an iframe for Images or Wells:
+
+::
+
+    $ omero config append omero.web.ui.right_plugins '["NGFF s3", "omero_web_zarr/right_panel_vizarr.html", "s3_vizarr"]'
+
 
 Testing
 -------

--- a/omero_web_zarr/render.py
+++ b/omero_web_zarr/render.py
@@ -1,0 +1,79 @@
+
+import os
+from ome_zarr.io import parse_url
+from ome_zarr.reader import Reader
+import numpy as np
+from PIL import Image
+import requests
+from pathlib import Path
+
+
+def render_image_to_pil(url):
+
+    # read the image data
+    reader = Reader(parse_url(url))
+    # nodes may include images, labels etc
+    nodes = list(reader())
+    # first node will be the image pixel data
+    image_node = nodes[0]
+
+    pyramid = image_node.data
+    # Use highest (full size) resolution of the pyramid
+    dask_data = pyramid[0]
+
+    # rgb = np.dstack((red, green, blue))
+    RED = (1, 0, 0)
+    GREEN = (0, 1, 0)
+    BLUE = (0, 0, 1)
+    YELLOW = (1, 1, 0)
+    WHITE = (1, 1, 1)
+
+    active_channels = [0, 1]
+    active_colors = [RED, GREEN]
+    active_windows = [[50, 4095], [50, 4095]]
+
+    rgb = setActiveChannels(dask_data, active_channels, active_colors, active_windows)
+    img = Image.fromarray(rgb)
+    return img
+
+
+def display(image, display_min, display_max): # copied from Bi Rico
+    # https://stackoverflow.com/questions/14464449/using-numpy-to-efficiently-convert-16-bit-image-data-to-8-bit-for-display-with
+    image.clip(display_min, display_max, out=image)
+    image -= display_min
+    np.floor_divide(image, (display_max - display_min + 1) / 256,
+                    out=image, casting='unsafe')
+    return image.astype(np.uint8)
+
+def render_plane(dask_data, z, c, t, window=None):
+    # slice 5D -> 2D
+    channel0 = dask_data[t, c, z, :, :]
+    channel0 = channel0.compute()
+
+    if window is None:
+        min_val = channel0.min()
+        max_val = channel0.max()
+        window = [min_val, max_val]
+
+    return display(channel0, window[0], window[1])
+
+
+def setActiveChannels(dask_data, active_indecies, colors, windows=None):
+    # colors are (r, g, b)
+    rgb_plane = None
+
+    the_z = 0
+    the_t = 0
+    for idx, ch_index in enumerate(active_indecies):
+        color = colors[idx]
+        window = windows[idx] if windows is not None else None
+        print("----", ch_index, color, window)
+        plane = render_plane(dask_data, the_t, ch_index, the_z, window)
+        if rgb_plane is None:
+            rgb_plane = np.zeros((*plane.shape, 3), np.uint16)
+        for index, fraction in enumerate(color):
+            if fraction > 0:
+                rgb_plane[:, :, index] += (fraction * plane)
+
+    rgb_plane.clip(0, 255, out=rgb_plane)
+    return rgb_plane.astype(np.uint8)

--- a/omero_web_zarr/templates/omero_web_zarr/right_panel_vizarr.html
+++ b/omero_web_zarr/templates/omero_web_zarr/right_panel_vizarr.html
@@ -1,0 +1,26 @@
+<script>
+    $(function() {
+
+       // omero config append omero.web.ui.right_plugins '["NGFF s3", "omero_web_zarr/right_panel_vizarr.html", "s3_vizarr"]'
+    
+       // Initialise the right tab plugin, on our specified tab element
+       $("#s3_vizarr").omeroweb_right_plugin({
+    
+           // Tab will only be enabled when a single image or well is selected
+           supported_obj_types: ['image', 'well'],
+    
+           // This will get called when tab is displayed or selected objects change
+           load_plugin_content: function(selected, obj_dtype, obj_id) {
+    
+               // since we only support single images, the obj_id will be an image ID
+               // Generate url based on a template-generated url
+               var url = `{% url 'omero_web_zarr_index' %}s3_vizarr/${obj_dtype}/${obj_id}/`;
+    
+               // Simply load the tab
+               $(this).load(url);
+           },
+    
+       });
+    
+    });
+    </script>

--- a/omero_web_zarr/templates/omero_web_zarr/s3_vizarr.html
+++ b/omero_web_zarr/templates/omero_web_zarr/s3_vizarr.html
@@ -1,0 +1,14 @@
+
+<html>
+
+    {% if s3_url %}
+    <a href="{{ s3_url }}">s3 URL</a>
+    <iframe name="vizarr" width="100%" height="90%" src="{{ VIZARR_URL }}?source={{ s3_url }}"></iframe>
+
+    {% else %}
+
+    No s3 URL available
+
+    {% endif %}
+
+</html>

--- a/omero_web_zarr/urls.py
+++ b/omero_web_zarr/urls.py
@@ -18,6 +18,7 @@
 from django.urls import re_path
 
 from . import views
+from omeroweb.webgateway import views as webgateway
 
 urlpatterns = [
 
@@ -42,4 +43,9 @@ urlpatterns = [
     # supports same rendering settings in query as webgateway/render_image
     re_path(r"^render_image/(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$",
             views.render_image, name="zarr_render_image"),
+    re_path(
+        r"^(?:(?P<share_id>[0-9]+)/)?imgData/(?P<iid>[0-9]+)/$",
+        views.imageData, name="web_imageData_json",
+    ),
+    re_path(r"^getImgRDef/$", webgateway.get_image_rdef_json, name="zarr_get_image_rdef_json")
 ]

--- a/omero_web_zarr/urls.py
+++ b/omero_web_zarr/urls.py
@@ -39,4 +39,7 @@ urlpatterns = [
     # Delegate all /vizarr/ or /validator/ urls to statically-hosted files
     re_path(r'^(?P<app>vizarr|validator)/(?P<url>.*)$', views.apps, name='zarr_app'),  # noqa
 
+    # supports same rendering settings in query as webgateway/render_image
+    re_path(r"^render_image/(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$",
+            views.render_image, name="zarr_render_image"),
 ]

--- a/omero_web_zarr/urls.py
+++ b/omero_web_zarr/urls.py
@@ -40,12 +40,20 @@ urlpatterns = [
     # Delegate all /vizarr/ or /validator/ urls to statically-hosted files
     re_path(r'^(?P<app>vizarr|validator)/(?P<url>.*)$', views.apps, name='zarr_app'),  # noqa
 
-    # supports same rendering settings in query as webgateway/render_image
+    # -- ALL URLs below are designed to work with public s3-hosted OME-Zarr Plates/Images ---
+
+    # -- The following URLs support using /zarr/ as the Preview panel base-url, which means we need
+    # to support all the derived URLs used by the Preview panel viewer...
+    # zarr/render_image/ supports same rendering settings in query as webgateway/render_image
     re_path(r"^render_image/(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$",
             views.render_image, name="zarr_render_image"),
     re_path(
         r"^(?:(?P<share_id>[0-9]+)/)?imgData/(?P<iid>[0-9]+)/$",
         views.imageData, name="web_imageData_json",
     ),
-    re_path(r"^getImgRDef/$", webgateway.get_image_rdef_json, name="zarr_get_image_rdef_json")
+    re_path(r"^getImgRDef/$", webgateway.get_image_rdef_json, name="zarr_get_image_rdef_json"),
+
+    # Alternative to the Preview is a right panel viewer that users vizarr for public s3 zarr
+    re_path(r"^s3_vizarr/(?P<c_type>(image|well))/(?P<c_id>[0-9]+)/$",
+            views.s3_vizarr, name="zarr_s3_vizarr"),
 ]

--- a/omero_web_zarr/views.py
+++ b/omero_web_zarr/views.py
@@ -38,6 +38,7 @@ from omero.model.enums import PixelsTypeuint32, PixelsTypefloat
 from omero.model.enums import PixelsTypedouble
 from omeroweb.webclient.decorators import login_required
 from omeroweb.webgateway.marshal import channelMarshal
+from omeroweb.webgateway.views import _get_prepared_image
 from omero.sys import ParametersI
 from omero.rtypes import rstring
 
@@ -370,10 +371,13 @@ def render_image(request, iid, z=None, t=None, conn=None, **kwargs):
         row_col_field = f"/{row}/{column}/{ws_index}/"
         zarr_path += row_col_field
 
+    # load Image and apply any rendering settings from request. e.g. ?c=...
+    image, quality = _get_prepared_image(request, iid, conn=conn)
+
     # Render the image... NB - hard-coded rendering settings for testing!
-    image = render_image_to_pil(zarr_path)
+    pil_img = render_image_to_pil(zarr_path, image)
     output = BytesIO()
-    image.save(output, "jpeg")
+    pil_img.save(output, "jpeg")
     jpeg_data = output.getvalue()
     output.close()
     return HttpResponse(jpeg_data, content_type="image/png")

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     download_url='%s/archive/v%s.tar.gz' % (HOMEPAGE, VERSION),  # NOQA
     packages=find_packages(),
     keywords=['omero', 'zarr', 'ome', 'web'],
-    install_requires=['zarr'],
+    install_requires=['zarr', 'ome-zarr'],
     include_package_data=True,
     zip_safe=False,
     cmdclass={'test': PyTest},


### PR DESCRIPTION
This is an experimental PR to evaluate different approaches to viewing NGFF data that has a public s3 URL `http.....zarr/.zattrs` set in the Fileset `clientPath` (shown as the "Imported From" location in webclient).

For NGFF Filesets (Plates and Images) that match this criteria, we can:

 - Show vizarr viewer instead of iviewer as the full image viewer
 - Add a right-panel tab that shows vizarr (beside the Preview tab)
 - We also support `/zarr/render_image/ID/` URL, similar to `/webgateway/render_image/ID` that uses `zarr` to load data direct from s3 URL and render the Image in python instead of using the OMERO server. 

See README changes for how to configure the 1st 2 options above.
To use the `/render_image/` functionality, we need changes to webclient...(to come in an omero-web PR)...